### PR TITLE
ci: Add CI linting with multi-version support and lint fixes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "blocc 'make lint'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,26 @@ jobs:
           versions=$(curl -s 'https://go.dev/dl/?mode=json' | jq -c 'map(.version[2:])')
           echo "versions=$versions" >> $GITHUB_OUTPUT
 
+  lint:
+    name: "Run linting"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+
+    - name: Run gofmt and go vet
+      run: |
+        make fmt-check
+        make vet
+
   test:
     name: "Run tests"
     needs: go-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,28 +16,8 @@ jobs:
           versions=$(curl -s 'https://go.dev/dl/?mode=json' | jq -c 'map(.version[2:])')
           echo "versions=$versions" >> $GITHUB_OUTPUT
 
-  lint:
-    name: "Run linting"
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: stable
-
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
-      with:
-        version: latest
-
-    - name: Run gofmt and go vet
-      run: |
-        make fmt-check
-        make vet
-
-  test:
-    name: "Run tests"
+  ci:
+    name: "CI"
     needs: go-versions
     runs-on: ubuntu-latest
     strategy:
@@ -61,6 +41,16 @@ jobs:
 
     - name: Download dependencies
       run: go mod download
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+
+    - name: Run gofmt and go vet
+      run: |
+        make fmt-check
+        make vet
 
     - name: Run tests
       run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,48 @@
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  enable:
+    - goimports
+    - govet
+    - errcheck
+    - staticcheck
+    - gosimple
+    - ineffassign
+    - typecheck
+    - gosec
+    - misspell
+    - lll
+    - nakedret
+    - prealloc
+    - gocritic
+    - gochecknoinits
+    - gocyclo
+    - gofmt
+    - goprintffuncname
+    - whitespace
+    - unconvert
+    - bodyclose
+    - rowserrcheck
+    - makezero
+    - revive
+    - exhaustive
+    - copyloopvar
+
+linters-settings:
+  lll:
+    line-length: 120
+  gocyclo:
+    min-complexity: 15
+  govet:
+    enable:
+      - shadow
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dupl
+        - gosec
+        - goconst

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,22 @@ test-integration:
 test-all:
 	go test -v ./...
 
+fmt-check:
+	@if [ -n "$$(gofmt -l .)" ]; then \
+		echo "The following files need formatting:"; \
+		gofmt -l .; \
+		exit 1; \
+	fi
+
+vet:
+	go vet ./...
+
+golangci-lint:
+	golangci-lint run
+
+lint: fmt-check vet golangci-lint
+
 install:
 	go install ./cmd/blocc
 
-.PHONY: build clean test test-integration test-all install
+.PHONY: build clean test test-integration test-all fmt-check vet lint install

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -13,9 +13,9 @@ var embedVersion = "0.1.0"
 
 type VersionFlag string
 
-func (v VersionFlag) Decode(ctx *kong.DecodeContext) error { return nil }
-func (v VersionFlag) IsBool() bool                         { return true }
-func (v VersionFlag) BeforeApply(app *kong.Kong, vars kong.Vars) error {
+func (v VersionFlag) Decode(_ *kong.DecodeContext) error { return nil }
+func (v VersionFlag) IsBool() bool                       { return true }
+func (v VersionFlag) BeforeApply(app *kong.Kong, _ kong.Vars) error {
 	if Version == "" {
 		Version = embedVersion
 	}

--- a/cmd/blocc/main.go
+++ b/cmd/blocc/main.go
@@ -20,7 +20,9 @@ func main() {
 	}
 
 	if len(results) > 0 {
-		blocc.OutputError(cliOptions.Message, results)
+		if outputErr := blocc.OutputError(cliOptions.Message, results); outputErr != nil {
+			ctx.Exit(1)
+		}
 		ctx.Exit(2)
 	}
 

--- a/executor.go
+++ b/executor.go
@@ -88,6 +88,7 @@ func (e *Executor) executeCommand(cmdStr string) Result {
 		}
 	}
 
+	// #nosec G204 - This is a CLI tool designed to execute user-provided commands
 	cmd := exec.Command(parts[0], parts[1:]...)
 
 	var stdout, stderr bytes.Buffer

--- a/integration/e2e_test.go
+++ b/integration/e2e_test.go
@@ -142,7 +142,7 @@ exit 1`
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
-	cmd.Run() // We expect this to fail
+	_ = cmd.Run() // We expect this to fail
 
 	var errOut ErrorOutput
 	if err := json.Unmarshal(stderr.Bytes(), &errOut); err != nil {
@@ -170,7 +170,7 @@ func TestBlocc_CustomMessage(t *testing.T) {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
-	cmd.Run() // We expect this to fail
+	_ = cmd.Run() // We expect this to fail
 
 	var errOut ErrorOutput
 	if err := json.Unmarshal(stderr.Bytes(), &errOut); err != nil {

--- a/output.go
+++ b/output.go
@@ -28,5 +28,5 @@ func OutputError(message string, results []Result) error {
 	}
 
 	fmt.Fprintln(os.Stderr, string(jsonBytes))
-	return fmt.Errorf("commands failed")
+	return nil
 }

--- a/output_test.go
+++ b/output_test.go
@@ -77,15 +77,11 @@ func TestOutputError(t *testing.T) {
 	}
 }
 
-func validateErrorOutput(t *testing.T, message string, results []Result, wantMessage string) {
+func validateErrorOutput(t *testing.T, _ string, results []Result, wantMessage string) {
 	// Create the expected output structure
 	expectedOutput := ErrorOutput{
 		Message: wantMessage,
 		Results: results,
-	}
-
-	if message == "" && len(results) > 0 {
-		// Message is already set with the correct format
 	}
 
 	// Validate JSON marshaling works


### PR DESCRIPTION
## Summary
- Add comprehensive linting configuration with golangci-lint
- Consolidate separate lint and test jobs into unified CI job
- Enable linting across all Go versions using matrix strategy
- Fix all lint errors across the codebase
- Add Claude Code hooks configuration for automatic linting

## Changes
- Add `.golangci.yml` with comprehensive linter configuration
- Update CI workflow to run linting on all Go versions
- Add Makefile targets for linting: `fmt-check`, `vet`, `golangci-lint`, and `lint`
- Fix lint errors:
  - Add proper error handling for `OutputError` return value
  - Fix unused parameter warnings
  - Add security exception comment for exec command
  - Fix ignored errors in tests
- Add `.claude/settings.json` for automatic linting on file changes

## Test plan
- [x] CI passes with all Go versions
- [x] All lint checks pass locally with `make lint`
- [x] Integration tests pass