### PR TITLE
feat: Support Stop hook and add interactive init command

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,8 @@
 {
   "hooks": {
-    "PostToolUse": [
+    "Stop": [
       {
-        "matcher": "Write|Edit|MultiEdit",
+        "matcher": "",
         "hooks": [
           {
             "type": "command",

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ This creates `./.claude/settings.local.json`:
 ```json
 {
   "hooks": {
-    "PostToolUse": [
+    "Stop": [
       {
-        "matcher": "Write|Edit|MultiEdit",
+        "matcher": "",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
## Summary
- Change Claude Code hook from PostToolUse to Stop with empty matcher
- Add interactive command input when no commands are provided to init
- Improve shell compatibility by changing command quoting style

## Changes by Component

### Hook Configuration (.claude/settings.json)
- Changed hook type from `PostToolUse` to `Stop`
- Changed matcher from `"Write|Edit|MultiEdit"` to empty string `""`
- This aligns with Claude Code's Stop hook specification

### Init Command (init.go)
- Added `getInteractiveCommands()` function for interactive command input
- Removed default commands (was `npx tsc --noEmit`)
- Now requires explicit command specification
- Changed command quoting from double quotes to single quotes for better shell compatibility
- Refactored code into smaller functions for better maintainability

### Tests (init_test.go, integration/e2e_test.go)
- Updated all tests to reflect PostToolUse → Stop change
- Removed tests for default behavior (since defaults were removed)
- Updated expected command strings to use single quotes
- Added explicit commands to tests that previously relied on defaults

## Test Plan
- [x] Unit tests pass (`go test ./...`)
- [x] Integration tests pass
- [ ] Manual testing of interactive init command
- [ ] Manual testing of Stop hook with Claude Code
- [ ] Verify backward compatibility is maintained for existing users