### PR TITLE
feat: Add stdout/stderr filter options for output processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,24 @@ blocc --message "Hook execution completed with errors. Please address the follow
 
 # Include stdout in error output(-s).
 blocc --stdout "npm run lint" "npm run test"
+
+# Filter output with stdout/stderr filters(-o/-e).
+# Example: Extract only unknown words from cspell output for easy review
+blocc -s -o "cspell lint . --cache --gitignore" -s -o "perl -nle 'print \$1 if /Unknown word \((\w+)\)/' | sort | uniq"
 ```
+
+### Output Filtering
+
+blocc supports filtering stdout and stderr through external commands using the `-o/--stdout-filter` and `-e/--stderr-filter` options. This is particularly useful for:
+
+- Removing ANSI color codes from terminal output
+- Extracting specific error patterns
+- Limiting output to relevant lines
+- Reformatting error messages
+
+The filter commands are executed via shell (`sh -c`), so you can use pipes and any command available in your shell. Common filter tools include `grep`, `sed`, `awk`, and `perl`.
+
+### Error Output Format
 
 When commands fail, blocc outputs a JSON structure to stderr. By default, only stderr is included. Use the `--stdout` flag to include stdout output from failed commands.
 

--- a/README.md
+++ b/README.md
@@ -68,41 +68,25 @@ Now when you use Claude Code's edit tools, it will automatically run the blocc c
 ## Usage
 
 ```bash
+$ blocc --help
+Usage: main [<commands> ...] [flags]
+
+Arguments:
+  [<commands> ...]    Commands to execute
+
+Flags:
+  -h, --help                    Show context-sensitive help.
+  -v, --version                 Show version information
+  -p, --parallel                Execute commands in parallel
+  -m, --message=STRING          Custom error message
+  -i, --init                    Initialize settings.local.json
+  -s, --stdout                  Include stdout in error output
+  -o, --stdout-filter=STRING    Filter command for stdout
+  -e, --stderr-filter=STRING    Filter command for stderr
+  -n, --no-stderr               Exclude stderr from error output
+
 # Execute commands sequentially (default).
-blocc "npm run lint" "npm run test"
-
-# Execute commands in parallel(-p).
-blocc --parallel "npm run lint" "npm run test" "npm run spell-check"
-
-# Custom error message(-m).
-blocc --message "Hook execution completed with errors. Please address the following issues" "npm run lint" "npm run test"
-
-# Include stdout in error output(-s).
-blocc --stdout "npm run lint" "npm run test"
-
-# Filter output with stdout/stderr filters(-o/-e).
-# Example: Extract only unknown words from cspell output for easy review
-blocc -s -o "cspell lint . --cache --gitignore" -s -o "perl -nle 'print \$1 if /Unknown word \((\w+)\)/' | sort | uniq"
-```
-
-### Output Filtering
-
-blocc supports filtering stdout and stderr through external commands using the `-o/--stdout-filter` and `-e/--stderr-filter` options. This is particularly useful for:
-
-- Removing ANSI color codes from terminal output
-- Extracting specific error patterns
-- Limiting output to relevant lines
-- Reformatting error messages
-
-The filter commands are executed via shell (`sh -c`), so you can use pipes and any command available in your shell. Common filter tools include `grep`, `sed`, `awk`, and `perl`.
-
-### Error Output Format
-
-When commands fail, blocc outputs a JSON structure to stderr. By default, only stderr is included. Use the `--stdout` flag to include stdout output from failed commands.
-
-```bash
 $ blocc "npm run lint" "npm run test"
-
 {
   "message": "2 command(s) failed",
   "results": [
@@ -118,22 +102,26 @@ $ blocc "npm run lint" "npm run test"
     }
   ]
 }
-```
 
-This is particularly useful for tools like `cspell` that output actual error details to stdout. Use the `--stdout` flag to capture this information.
+# Execute commands in parallel(-p).
+$ blocc --parallel "npm run lint" "npm run test" "npm run spell-check"
 
-```bash
-$ blocc --stdout "cspell lint . --cache --gitignore"
+# Custom error message(-m).
+$ blocc --message "Hook execution completed with errors. Please address the following issues" "npm run lint" "npm run test"
 
+# Include stdout in error output(-s).
+$ blocc --stdout "npm run lint" "npm run test"
+
+# Filter output for context engineering(-o/-e).
+$ blocc -n -s "cspell lint . --cache --gitignore" -o "perl -nle 'print \$1 if /Unknown word \((\w+)\)/' | sort | uniq"
 {
   "message": "1 command(s) failed",
   "results": [
     {
       "command": "cspell lint . --cache --gitignore",
       "exitCode": 1,
-      "stderr": "CSpell: Files checked: 39, Issues found: 2 in 1 file.",
-      "stdout": "packages/iac/lib/deploy-role-stack.ts:15:11 - Unknown word (oicd)"
+      "stdout": "alecthomas\nBINPATH\nblocc\nBlocc\nclippy\nDISTPATH\ngofmt\ngolangci\nGOPATH\ngoreleaser\ngotextdiff\nhexops\nnonexistentcommand\nnosec\noicd\nprintln\nrepr\nshuntaka\nvxeg\n"
     }
   ]
 }
-```
+````

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -34,6 +34,7 @@ type CLI struct {
 	Stdout       bool        `help:"Include stdout in error output" short:"s"`
 	StdoutFilter string      `help:"Filter command for stdout" short:"o"`
 	StderrFilter string      `help:"Filter command for stderr" short:"e"`
+	NoStderr     bool        `help:"Exclude stderr from error output" short:"n"`
 }
 
 func Parse() (*CLI, *kong.Context) {

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -26,12 +26,14 @@ func (v VersionFlag) BeforeApply(app *kong.Kong, _ kong.Vars) error {
 }
 
 type CLI struct {
-	Version  VersionFlag `name:"version" help:"Show version information" short:"v"`
-	Commands []string    `arg:"" name:"commands" help:"Commands to execute" optional:""`
-	Parallel bool        `help:"Execute commands in parallel" short:"p"`
-	Message  string      `help:"Custom error message" short:"m"`
-	Init     bool        `help:"Initialize settings.local.json" short:"i"`
-	Stdout   bool        `help:"Include stdout in error output" short:"s"`
+	Version      VersionFlag `name:"version" help:"Show version information" short:"v"`
+	Commands     []string    `arg:"" name:"commands" help:"Commands to execute" optional:""`
+	Parallel     bool        `help:"Execute commands in parallel" short:"p"`
+	Message      string      `help:"Custom error message" short:"m"`
+	Init         bool        `help:"Initialize settings.local.json" short:"i"`
+	Stdout       bool        `help:"Include stdout in error output" short:"s"`
+	StdoutFilter string      `help:"Filter command for stdout" short:"o"`
+	StderrFilter string      `help:"Filter command for stderr" short:"e"`
 }
 
 func Parse() (*CLI, *kong.Context) {

--- a/cmd/blocc/main.go
+++ b/cmd/blocc/main.go
@@ -18,6 +18,7 @@ func main() {
 			cliOptions.Stdout,
 			cliOptions.StdoutFilter,
 			cliOptions.StderrFilter,
+			cliOptions.NoStderr,
 		)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -32,7 +33,7 @@ func main() {
 		ctx.Exit(1)
 	}
 
-	executor := blocc.NewExecutor(cliOptions.Stdout, cliOptions.StdoutFilter, cliOptions.StderrFilter)
+	executor := blocc.NewExecutor(cliOptions.Stdout, cliOptions.StdoutFilter, cliOptions.StderrFilter, cliOptions.NoStderr)
 
 	var results []blocc.Result
 	var err error

--- a/cmd/blocc/main.go
+++ b/cmd/blocc/main.go
@@ -12,7 +12,14 @@ func main() {
 	cliOptions, ctx := cli.Parse()
 
 	if cliOptions.Init {
-		if err := blocc.InitSettings(cliOptions.Commands, cliOptions.Message, cliOptions.Stdout); err != nil {
+		err := blocc.InitSettings(
+			cliOptions.Commands,
+			cliOptions.Message,
+			cliOptions.Stdout,
+			cliOptions.StdoutFilter,
+			cliOptions.StderrFilter,
+		)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			ctx.Exit(1)
 		}
@@ -25,7 +32,7 @@ func main() {
 		ctx.Exit(1)
 	}
 
-	executor := blocc.NewExecutor(cliOptions.Stdout)
+	executor := blocc.NewExecutor(cliOptions.Stdout, cliOptions.StdoutFilter, cliOptions.StderrFilter)
 
 	var results []blocc.Result
 	var err error

--- a/executor_test.go
+++ b/executor_test.go
@@ -45,7 +45,7 @@ func TestExecuteCommand(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			executor := NewExecutor(false, "", "")
+			executor := NewExecutor(false, "", "", false)
 			result := executor.executeCommand(tt.command)
 
 			if result.ExitCode != tt.wantExitCode {
@@ -82,7 +82,7 @@ func TestExecuteCommandWithStdout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			executor := NewExecutor(true, "", "") // Enable stdout
+			executor := NewExecutor(true, "", "", false) // Enable stdout
 			result := executor.executeCommand(tt.command)
 
 			if result.ExitCode != tt.wantExitCode {
@@ -125,7 +125,7 @@ func TestExecuteSequential(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			executor := NewExecutor(false, "", "")
+			executor := NewExecutor(false, "", "", false)
 			results, _ := executor.ExecuteSequential(tt.commands)
 
 			if len(results) != tt.wantResults {
@@ -155,7 +155,7 @@ func TestExecuteParallel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			executor := NewExecutor(false, "", "")
+			executor := NewExecutor(false, "", "", false)
 			results, _ := executor.ExecuteParallel(tt.commands)
 
 			if len(results) < tt.wantMinResults {
@@ -211,12 +211,57 @@ func TestExecuteCommandWithFilters(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			executor := NewExecutor(tt.includeStdout, tt.stdoutFilter, tt.stderrFilter)
+			executor := NewExecutor(tt.includeStdout, tt.stdoutFilter, tt.stderrFilter, false)
 			result := executor.executeCommand(tt.command)
 
 			if result.Stdout != tt.wantStdout {
 				t.Errorf("executeCommand() stdout = %v, want %v", result.Stdout, tt.wantStdout)
 			}
+
+			if result.Stderr != tt.wantStderr {
+				t.Errorf("executeCommand() stderr = %v, want %v", result.Stderr, tt.wantStderr)
+			}
+		})
+	}
+}
+
+func TestNoStderrOption(t *testing.T) {
+	tests := []struct {
+		name       string
+		command    string
+		noStderr   bool
+		wantStderr string
+	}{
+		{
+			name:       "stderr included by default",
+			command:    "false",
+			noStderr:   false,
+			wantStderr: "",
+		},
+		{
+			name:       "stderr excluded with no-stderr option",
+			command:    "false",
+			noStderr:   true,
+			wantStderr: "",
+		},
+		{
+			name:       "empty command with no-stderr",
+			command:    "",
+			noStderr:   true,
+			wantStderr: "",
+		},
+		{
+			name:       "non-existent command with no-stderr",
+			command:    "nonexistentcommand123",
+			noStderr:   true,
+			wantStderr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := NewExecutor(false, "", "", tt.noStderr)
+			result := executor.executeCommand(tt.command)
 
 			if result.Stderr != tt.wantStderr {
 				t.Errorf("executeCommand() stderr = %v, want %v", result.Stderr, tt.wantStderr)

--- a/init.go
+++ b/init.go
@@ -46,61 +46,45 @@ func getInteractiveCommandsFromReader(reader io.Reader) ([]string, error) {
 	return commands, nil
 }
 
-func getInteractiveSettings() ([]string, bool, string, string, error) {
+func askYesNo(scanner *bufio.Scanner, prompt string) bool {
+	fmt.Print(prompt)
+	if scanner.Scan() {
+		response := strings.ToLower(strings.TrimSpace(scanner.Text()))
+		return response == "y" || response == "yes"
+	}
+	return false
+}
+
+func askFilterCommand(scanner *bufio.Scanner, filterType string) string {
+	if askYesNo(scanner, fmt.Sprintf("Add %s filter? (y/N): ", filterType)) {
+		fmt.Printf("Enter %s filter command: ", filterType)
+		if scanner.Scan() {
+			return strings.TrimSpace(scanner.Text())
+		}
+	}
+	return ""
+}
+
+func getInteractiveSettings() ([]string, bool, string, string, bool, error) {
 	scanner := bufio.NewScanner(os.Stdin)
 
-	// Ask about stdout first
-	fmt.Print("Include stdout in error output? (y/N): ")
-	includeStdout := false
-	if scanner.Scan() {
-		response := strings.ToLower(strings.TrimSpace(scanner.Text()))
-		includeStdout = response == "y" || response == "yes"
-	}
+	// Ask about stdout
+	includeStdout := askYesNo(scanner, "Include stdout in error output? (y/N): ")
 
-	// Ask about stdout filter
-	fmt.Print("Add stdout filter? (y/N): ")
-	var stdoutFilter string
-	if scanner.Scan() {
-		response := strings.ToLower(strings.TrimSpace(scanner.Text()))
-		if response == "y" || response == "yes" {
-			fmt.Print("Enter stdout filter command: ")
-			if scanner.Scan() {
-				stdoutFilter = strings.TrimSpace(scanner.Text())
-			}
-		}
-	}
+	// Ask about filters
+	stdoutFilter := askFilterCommand(scanner, "stdout")
+	stderrFilter := askFilterCommand(scanner, "stderr")
 
-	// Ask about stderr filter
-	fmt.Print("Add stderr filter? (y/N): ")
-	var stderrFilter string
-	if scanner.Scan() {
-		response := strings.ToLower(strings.TrimSpace(scanner.Text()))
-		if response == "y" || response == "yes" {
-			fmt.Print("Enter stderr filter command: ")
-			if scanner.Scan() {
-				stderrFilter = strings.TrimSpace(scanner.Text())
-			}
-		}
-	}
+	// Ask about no-stderr option
+	noStderr := askYesNo(scanner, "Exclude stderr from error output? (y/N): ")
 
 	// Then ask for commands
-	fmt.Println("Enter commands to run (one per line, empty line to finish):")
-	var commands []string
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			break
-		}
-		commands = append(commands, line)
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, false, "", "", fmt.Errorf("failed to read input: %w", err)
-	}
-	if len(commands) == 0 {
-		return nil, false, "", "", fmt.Errorf("no commands provided")
+	commands, err := getInteractiveCommandsFromReader(os.Stdin)
+	if err != nil {
+		return nil, false, "", "", false, err
 	}
 
-	return commands, includeStdout, stdoutFilter, stderrFilter, nil
+	return commands, includeStdout, stdoutFilter, stderrFilter, noStderr, nil
 }
 
 func askIncludeStdoutFromReader(reader io.Reader) (bool, error) {
@@ -122,6 +106,7 @@ func buildCommandString(
 	message string,
 	includeStdout bool,
 	stdoutFilter, stderrFilter string,
+	noStderr bool,
 ) string {
 	quotedCommands := make([]string, len(commands))
 	for i, cmd := range commands {
@@ -139,6 +124,9 @@ func buildCommandString(
 	}
 	if stderrFilter != "" {
 		commandStr += fmt.Sprintf(" --stderr-filter \"%s\"", stderrFilter)
+	}
+	if noStderr {
+		commandStr += " --no-stderr"
 	}
 	commandStr += " " + strings.Join(quotedCommands, " ")
 	return commandStr
@@ -160,7 +148,13 @@ func createSettings(commandStr string) Settings {
 	return settings
 }
 
-func InitSettings(commands []string, message string, includeStdout bool, stdoutFilter, stderrFilter string) error {
+func InitSettings(
+	commands []string,
+	message string,
+	includeStdout bool,
+	stdoutFilter, stderrFilter string,
+	noStderr bool,
+) error {
 	currentDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current directory: %w", err)
@@ -178,7 +172,7 @@ func InitSettings(commands []string, message string, includeStdout bool, stdoutF
 
 	// If no commands provided, ask interactively
 	if len(commands) == 0 {
-		commands, includeStdout, stdoutFilter, stderrFilter, err = getInteractiveSettings()
+		commands, includeStdout, stdoutFilter, stderrFilter, noStderr, err = getInteractiveSettings()
 		if err != nil {
 			return err
 		}
@@ -191,7 +185,7 @@ func InitSettings(commands []string, message string, includeStdout bool, stdoutF
 	}
 
 	// Build command string
-	commandStr := buildCommandString(commands, message, includeStdout, stdoutFilter, stderrFilter)
+	commandStr := buildCommandString(commands, message, includeStdout, stdoutFilter, stderrFilter, noStderr)
 
 	// Create settings structure
 	settings := createSettings(commandStr)

--- a/init_test.go
+++ b/init_test.go
@@ -53,7 +53,7 @@ func TestInitSettings(t *testing.T) {
 			}
 
 			// Run InitSettings
-			err = InitSettings(tt.commands, tt.message, false, "", "")
+			err = InitSettings(tt.commands, tt.message, false, "", "", false)
 			if err != nil {
 				t.Fatalf("InitSettings failed: %v", err)
 			}
@@ -127,7 +127,7 @@ func TestInitSettings_FileAlreadyExists(t *testing.T) {
 	}
 
 	// Should fail when file already exists
-	err = InitSettings([]string{"echo test"}, "", false, "", "")
+	err = InitSettings([]string{"echo test"}, "", false, "", "", false)
 	if err == nil {
 		t.Error("Expected error when file already exists, got nil")
 	}
@@ -154,7 +154,7 @@ func TestInitSettings_PathDisplay(t *testing.T) {
 	// Capture output by redirecting stdout temporarily
 	// Note: In real implementation, we would need to capture the output
 	// For now, just ensure the function succeeds
-	err = InitSettings([]string{"echo test"}, "", false, "", "")
+	err = InitSettings([]string{"echo test"}, "", false, "", "", false)
 	if err != nil {
 		t.Fatalf("InitSettings failed: %v", err)
 	}
@@ -180,7 +180,7 @@ func TestInitSettings_ValidJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = InitSettings([]string{"echo test"}, "Test message", false, "", "")
+	err = InitSettings([]string{"echo test"}, "Test message", false, "", "", false)
 	if err != nil {
 		t.Fatalf("InitSettings failed: %v", err)
 	}
@@ -220,7 +220,7 @@ func TestInitSettings_WithStdout(t *testing.T) {
 	}
 
 	// Test with stdout enabled
-	err := InitSettings([]string{"echo test"}, "Test message", true, "", "")
+	err := InitSettings([]string{"echo test"}, "Test message", true, "", "", false)
 	if err != nil {
 		t.Fatalf("InitSettings failed: %v", err)
 	}
@@ -435,20 +435,12 @@ func TestInitSettings_WithFilters(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create temporary directory for test
 			tmpDir := t.TempDir()
-			originalWd, err := os.Getwd()
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() {
-				_ = os.Chdir(originalWd)
-			}()
-
-			if err = os.Chdir(tmpDir); err != nil {
+			if err := os.Chdir(tmpDir); err != nil {
 				t.Fatal(err)
 			}
 
 			// Run InitSettings
-			err = InitSettings(tt.commands, tt.message, tt.includeStdout, tt.stdoutFilter, tt.stderrFilter)
+			err := InitSettings(tt.commands, tt.message, tt.includeStdout, tt.stdoutFilter, tt.stderrFilter, false)
 			if err != nil {
 				t.Fatalf("InitSettings failed: %v", err)
 			}


### PR DESCRIPTION
- Add --stdout-filter/-o and --stderr-filter/-e CLI options
- Enable filtering command output through external tools
- Support interactive filter configuration in init command
- Update documentation with filter examples (cspell pattern extraction)